### PR TITLE
Upgrade to Python 3.6.2-1

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 SHELL := /bin/bash
 
-VERSION := 3.6.1-2
+VERSION := 3.6.2-1
 WORKDIR := python3.6-$(shell cut -d- -f1 <<< '$(VERSION)')
 
 .PHONY: builddeb

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 Python 3.6 Debian stretch backport
 ========
 
-Unofficial Python 3.6 backports for Debian stretch.
+Unofficial Python 3.6.2 backports for Debian stretch.
 
 
 ## Usage
@@ -13,7 +13,7 @@ dpkg -i *.deb` to install them.
 For example, a typical installation could look like this:
 
 ```bash
-$ wget https://github.com/chriskuehl/python3.6-debian-stretch/releases/download/v3.6.1-2-deb9u1/{python3.6_3.6.1-2.deb9u1_amd64,python3.6-minimal_3.6.1-2.deb9u1_amd64,python3.6-dev_3.6.1-2.deb9u1_amd64,libpython3.6_3.6.1-2.deb9u1_amd64,libpython3.6-minimal_3.6.1-2.deb9u1_amd64,libpython3.6-stdlib_3.6.1-2.deb9u1_amd64,libpython3.6-dev_3.6.1-2.deb9u1_amd64}.deb
+$ wget https://github.com/chriskuehl/python3.6-debian-stretch/releases/download/v3.6.2-1-deb9u1/{python3.6_3.6.2-1.deb9u1_amd64,python3.6-minimal_3.6.2-1.deb9u1_amd64,python3.6-dev_3.6.2-1.deb9u1_amd64,libpython3.6_3.6.2-1.deb9u1_amd64,libpython3.6-minimal_3.6.2-1.deb9u1_amd64,libpython3.6-stdlib_3.6.2-1.deb9u1_amd64,libpython3.6-dev_3.6.2-1.deb9u1_amd64}.deb
 $ sudo dpkg -i *.deb
 ```
 


### PR DESCRIPTION
`3.6.1-2` => `3.6.2-1`

I believe this upgrade is compatible with already-existing python 3.6.1 virtualenvs, but I can't guarantee it (it could be incompatible and you'd have to either downgrade back to 3.6.1 or rebuild those virtualenvs).

The `3.6.0` => `3.6.1` upgrade was _not_ safe due to some changes in the `weakref` module, but so far I haven't found any issues in `3.6.1` => `3.6.2`.